### PR TITLE
adding CW Logs invoke permission and output for function ARN

### DIFF
--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -27,3 +27,13 @@ Resources:
       Policies:
         - KMSDecryptPolicy:
             KeyId: !Ref KmsKeyId
+  LambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref NewRelicLogIngestionFunction
+      Action: lambda:InvokeFunction
+      Principal: !Sub logs.${AWS::Region}.amazonaws.com
+      SourceArn: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
+Outputs:
+  NewRelicLogIngestionFunctionArn:
+    Value: !GetAtt NewRelicLogIngestionFunction.Arn


### PR DESCRIPTION
### Issue

Received CloudFormation stack event error when creating an AWS::Logs::SubscriptionFilter resource:

> "Could not execute the lambda function. Make sure you have given CloudWatch Logs permission to execute your function."

Sample CFN resource that produced the error:

```yaml
  LambdaLogSubscriptionFilter:
    Type: AWS::Logs::SubscriptionFilter
    DependsOn:
    - LambdaLogGroup
    Properties:
      LogGroupName: !Sub /aws/lambda/${Lambda}
      FilterPattern: ""
      DestinationArn: !Ref NewRelicLogIngestionFunctionArn
```

Discovered the following: 

* Lambda function created by the Serverless Application Repository template had an empty Function Policy
* It required invoke permissions for CloudWatch Logs (AWS::Lambda::Permission) 

### Fix 

Fixed with the following command:

```bash
aws lambda add-permission --function-name arn:aws:lambda:${AWSRegion}:${AWSAccountId}:function:newrelic-log-ingestion --statement-id cw-logs-access --action lambda:InvokeFunction --principal logs.${AWSRegion}.amazonaws.com
```

### Proposed changes

In testing the PR changes below for the SAM template appear to resolve the issue.