### PR TITLE
Add Params for Environment Variables

### DIFF
--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -6,6 +6,14 @@ Parameters:
     Type: String
     Description: Your NewRelic license key. You may omit it when deploying the function.
     Default: "YOUR_LICENSE_KEY"
+  NRLoggingEnabled:
+    Type: String
+    Description: Determines if logs are forwarded to New Relic Logging
+    Default: "False"
+  NRInfraLogging:
+    Type: String
+    Description: Determines if logs are forwarded to New Relic Infrastructure
+    Default: "False"
 
 Resources:
   NewRelicLogIngestionFunction:
@@ -19,8 +27,10 @@ Resources:
       FunctionName: newrelic-log-ingestion
       Timeout: 30
       Environment:
-        Variables: 
+        Variables:
           LICENSE_KEY: !Ref NRLicenseKey
+          LOGGING_ENABLED: !Ref NRLoggingEnabled
+          INFRA_ENABLED: !Ref NRInfraLogging
 
   LambdaInvokePermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
The serverless template doesn't currently allow a user to pass required environment variables.

When deploying the template from the AWS Lambda console it is confusing to have the enviroment variables listed as configurable and not be able to set them all (you can only set the license key).

![image](https://user-images.githubusercontent.com/17018403/73499181-a1561380-437c-11ea-98df-cdbb2a5ba4f5.png)

In addition, if using Cloud Formation to deploy the serverless app there is no way to automate creation of the variables since the nested stack's template won't accept the parameters.

