### PR TITLE
Add the ability to read the license key from AWS secrets manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ packaged.yaml
 node_modules
 package.json
 package-lock.json
+
+.python-version
+build/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To forward data to New Relic: [New Relic License Key](https://docs.newrelic.com/
 
 ## Configuration
 
-You can configure forwarding of logs to New Relic Infrastructure and/or New Relic Logging using the following two environment variables.
+You can configure forwarding of logs to New Relic Infrastructure and/or New Relic Logging using the following environment variables.
 
 | Env. Variable | Behavior | Value |
 |---------------|----------|----------------------------|
@@ -24,6 +24,7 @@ You can configure forwarding of logs to New Relic Infrastructure and/or New Reli
 |---------------|------------|---------------------------|
 | NR_LOGGING_ENDPOINT |  New Relic ingestion endpoint for Logging | `https://log-api.newrelic.com/log/v1` |
 | NR_INFRA_ENDPOINT |  New Relic ingestion endpoint for Infra | `https://cloud-collector.newrelic.com` |
+| SECRET_KEY_ARN |  Use the specified ARN to obtain the license key from AWS secrets manager, rather than LICENSE_KEY variable | (empty) |
 
 
 ## Configure a Lambda trigger for logging

--- a/build-zip.sh
+++ b/build-zip.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# For those unable to use SAM, this builds a zip file that can be deployed using the AWS CLI or terraform or the like.
+# The resulting zip will be placed in the build directory. It uses a python3 virtual environment, per the
+# instructions here: https://docs.aws.amazon.com/lambda/latest/dg/python-package.html
+
+# A suffix may be added to the zip name by defining the SUFFIX environment variable before invoking this script.
+
+# Constants
+BUILDDIR=build
+
+# Extract the version from the template.yaml file
+VERSION=`grep SemanticVersion template.yaml | sed -e 's/ *SemanticVersion: *//'`
+ZIPFILE=newrelic-log-ingestion-${VERSION}${SUFFIX}.zip
+
+# Clean up any old build
+echo "Cleaning old builds..."
+rm -rf ${BUILDDIR}
+
+# Create the virtual environment, and activate it
+echo "Setting up virtual environment..."
+python3 -m venv ${BUILDDIR}
+source build/bin/activate
+
+# Install the requirements, excluding boto3, which is pre-installed in AWS
+echo "Installing dependencies..."
+cat src/requirements.txt | grep -v boto3 > /tmp/requirements.txt
+pip3 --disable-pip-version-check install --requirement /tmp/requirements.txt
+
+# Deactivate the virtual environment
+deactivate
+
+# Package up the dependencies
+echo "Creating zip of dependencies..."
+(cd ${BUILDDIR}/lib/python*/site-packages && zip --quiet --recurse-paths -9 ../../../${ZIPFILE} .)
+
+# Add the function to the zip file
+echo "Adding function to zip..."
+(cd src && zip --grow --quiet ../${BUILDDIR}/${ZIPFILE} function.py)
+
+# All done!
+echo "Done, zipfile: ${BUILDDIR}/${ZIPFILE}"
+

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,6 +2,7 @@
 aiohttp==4.0.0a1
 async-timeout==3.0.1
 attrs==19.3.0
+boto3==1.14.9
 chardet==3.0.4
 idna==2.9
 multidict==4.7.5


### PR DESCRIPTION
Adds a new environment variable, `SECRET_KEY_ARN`. If set, the lambda uses that to read the license key from AWS secrets manager. The `_get_license_key` method is called multiple times during a single lambda run, so I created a global variable to store the result, to avoid multiple calls to secrets manager.

This change also adds a simple shell script to automate creation of a `.zip` file for deployment, for those that might be unable to use `SAM` for deployment (perhaps they use `terraform` or some other tool to automate their deployments).