### PR TITLE
Add optional PermissionsBoundary parameter

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -39,6 +39,9 @@ Parameters:
     Description: |
       The export name suffix for the function ARN
     Default: LogIngestionFunctionArn
+  PermissionsBoundary:
+    Type: String
+    Description: IAM Role PermissionsBoundary (optional)
 
 Conditions:
   NoRole: !Equals ['', !Ref FunctionRole]
@@ -69,6 +72,7 @@ Resources:
       MemorySize:
         Ref: MemorySize
       Runtime: python3.7
+      PermissionsBoundary: !Ref PermissionsBoundary
       Role: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${FunctionRole}
       Timeout:
         Ref: Timeout
@@ -89,6 +93,7 @@ Resources:
       MemorySize:
         Ref: MemorySize
       Runtime: python3.7
+      PermissionsBoundary: !Ref PermissionsBoundary
       Timeout:
         Ref: Timeout
       Environment:


### PR DESCRIPTION
It's an optional parameter to AWS::Serverless::Function that allows setting the PermissionsBoundary property of the AWS::IAM::Role resource

This is requred by corporate IAM policy at my work

This PR is to add --aws-permissions-boundary parameter to newrelic/newrelic-lambda-cli#102 