### PR TITLE
Add aws.requestId to Log Message if the lambda_request_id is found

### DIFF
--- a/src/function.py
+++ b/src/function.py
@@ -452,6 +452,9 @@ def _package_log_payload(data):
                 log_message["attributes"]["aws"][
                     "lambda_request_id"
                 ] = lambda_request_id
+                log_message["attributes"]["aws"][
+                    "requestId"
+                ] = lambda_request_id
 
         log_messages.append(log_message)
 

--- a/test/log_ingestion_test.py
+++ b/test/log_ingestion_test.py
@@ -496,14 +496,19 @@ def test_lambda_request_ids_are_extracted(mock_aio_post):
     assert len(messages) == 5
     assert messages[0]["timestamp"] == timestamp
     assert messages[0]["attributes"]["aws"]["lambda_request_id"] == expected_request_id
+    assert messages[0]["attributes"]["aws"]["requestId"] == expected_request_id
     assert messages[1]["timestamp"] == timestamp
     assert messages[1]["attributes"]["aws"]["lambda_request_id"] == expected_request_id
+    assert messages[1]["attributes"]["aws"]["requestId"] == expected_request_id
     assert messages[2]["timestamp"] == timestamp
     assert messages[2]["attributes"]["aws"]["lambda_request_id"] == expected_request_id
+    assert messages[2]["attributes"]["aws"]["requestId"] == expected_request_id
     assert messages[3]["timestamp"] == timestamp
     assert messages[3]["attributes"]["aws"]["lambda_request_id"] == expected_request_id
+    assert messages[3]["attributes"]["aws"]["requestId"] == expected_request_id
     assert messages[4]["timestamp"] == timestamp
-    assert messages[4]["attributes"]["aws"]["lambda_request_id"] == expected_request_id2
+    assert messages[4]["attributes"]["aws"]["lambda_request_id"] == expected_request_id
+    assert messages[4]["attributes"]["aws"]["requestId"] == expected_request_id
 
 
 async def aio_post_response():


### PR DESCRIPTION
This copies the value that is set in `aws.lambda_request_id` to `aws.requestId` on the log message dictionary that is ultimately submitted to the New Relic Logs API.

The reason for this is to support a use case leveraging Insights dashboards that combine data from `AwsLambdaInvocation` and `Log` NRQL queries along with the [Filter New Relic One dashboards by facets](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets). The idea being to:
1. Build a query / chart that fetches matching Invocations
2. Leverage the filtering feature to filter the dashboard
3. Fetch logs relevant to the specific invocation that is selected

The way the filtering feature is built is it seems to leverage the exact field name from the source chart that is being used as a filter. In the case of `AwsLambdaInvocation`, this is named `aws.requestId`. With current behavior, this will effectively filter out all logs, since this field is not populated in the `Log` entity.