### PR TITLE
[LOGGING_4864] Consider timeout errors and add logging debug statements

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -16,6 +16,8 @@ provider:
     LICENSE_KEY: ${env:LICENSE_KEY}
     # Determines if logs are forwarded to New Relic Logging
     LOGGING_ENABLED: ${env:LOGGING_ENABLED, "False"}
+    # A boolean to determine if you want to output debug messages in the CloudWatch console
+    DEBUG_LOGGING_ENABLED: ${env:DEBUG_LOGGING_ENABLED, "False"}
 
 custom:
   pythonRequirements:
@@ -32,7 +34,7 @@ package:
 
 functions:
   newrelic-log-ingestion:
-    description: Send log data from CloudWatch Logs and S3 to New Relic Infrastructure (Cloud Integrations) and New Relic Logging.
+    description: Send log data from CloudWatch Logs to New Relic Infrastructure (Cloud Integrations) and New Relic Logging.
     handler: src/function.lambda_handler
     name: newrelic-log-ingestion
 

--- a/src/function.py
+++ b/src/function.py
@@ -37,8 +37,10 @@ https://docs.newrelic.com/
 import datetime
 import gzip
 import json
+import logging
 import os
 import re
+import time
 
 from base64 import b64decode
 from enum import Enum
@@ -46,6 +48,8 @@ from urllib import request
 
 import aiohttp
 import asyncio
+
+logger = logging.getLogger()
 
 try:
     import newrelic.agent
@@ -58,8 +62,10 @@ else:
 # Retrying configuration.
 # Increasing these numbers will make the function longer in case of
 # communication failures and that will increase the cost.
-# Decreasing these number could increase the probility of data loss.
+# Decreasing these number could increase the probability of data loss.
 
+# Upon receiving the following error codes, the request will be retried up to MAX_RETRIES times
+RETRYABLE_ERROR_CODES = [408, 429]
 # Maximum number of retries
 MAX_RETRIES = 3
 # Initial backoff (in seconds) between retries
@@ -68,6 +74,14 @@ INITIAL_BACKOFF = 1
 BACKOFF_MULTIPLIER = 2
 # Max length in bytes of the payload
 MAX_PAYLOAD_SIZE = 1000 * 1024
+# Individual request timeout in seconds (non-configurable)
+INDIVIDUAL_REQUEST_TIMEOUT_DURATION = 3
+INDIVIDUAL_REQUEST_TIMEOUT = aiohttp.ClientTimeout(
+    total=INDIVIDUAL_REQUEST_TIMEOUT_DURATION
+)
+# Session max processing time (non-configurable).
+# Reserves a time buffer for logs to be formatted before being sent.
+SESSION_MAX_PROCESSING_TIME = 1
 
 LAMBDA_LOG_GROUP_PREFIX = "/aws/lambda"
 VPC_LOG_GROUP_PREFIX = "/aws/vpc/flow-logs"
@@ -104,7 +118,7 @@ LAMBDA_REQUEST_ID_REGEX = re.compile(
     r"(?P<request_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
 )
 
-LOGGING_LAMBDA_VERSION = "1.0.2"
+LOGGING_LAMBDA_VERSION = "1.0.3"
 LOGGING_PLUGIN_METADATA = {"type": "lambda", "version": LOGGING_LAMBDA_VERSION}
 
 
@@ -125,14 +139,16 @@ async def http_post(session, url, data, headers):
 
     while retries < MAX_RETRIES:
         if retries > 0:
-            print("Retrying in {} seconds".format(backoff))
+            logger.info("Retrying in {} seconds".format(backoff))
             await asyncio.sleep(backoff)
             backoff *= BACKOFF_MULTIPLIER
 
         retries += 1
 
         try:
-            resp = await session.post(url, data=data, headers=headers)
+            resp = await session.post(
+                url, data=data, headers=headers, timeout=INDIVIDUAL_REQUEST_TIMEOUT
+            )
             resp.raise_for_status()
             return resp.status, resp.url
         except aiohttp.ClientResponseError as e:
@@ -144,12 +160,16 @@ async def http_post(session, url, data, headers):
                 raise BadRequestException(
                     _format_error(e, "Review the region endpoint")
                 )
-            elif e.status == 429:
-                print("There was a {} error. Reason: {}".format(e.status, e.message))
+            elif e.status in RETRYABLE_ERROR_CODES:
+                logger.warning(f"There was a {e.status} error. Reason: {e.message}")
                 # Now retry the request
                 continue
             elif 400 <= e.status < 500:
                 raise BadRequestException(e)
+        except asyncio.TimeoutError:
+            logger.warning(f"Timeout on {url} at attempt {retries}/{MAX_RETRIES}")
+            # Now retry the request
+            continue
 
     raise MaxRetriesException()
 
@@ -169,6 +189,20 @@ def _filter_log_lines(log_entry):
     return ret
 
 
+def _calculate_session_timeout():
+    # Request 0
+    total = INDIVIDUAL_REQUEST_TIMEOUT_DURATION
+
+    # Requests 1 to N-1
+    backoff = INITIAL_BACKOFF
+    for retry in range(MAX_RETRIES - 1):
+        total += backoff + INDIVIDUAL_REQUEST_TIMEOUT_DURATION
+        backoff *= BACKOFF_MULTIPLIER
+
+    # Finally, add maximum worst-case-scenario expected processing time
+    return total + SESSION_MAX_PROCESSING_TIME
+
+
 async def _send_log_entry(log_entry, context):
     """
     This function sends the log entry to New Relic Infrastructure's ingest
@@ -184,7 +218,11 @@ async def _send_log_entry(log_entry, context):
         "log_stream_name": context.log_stream_name,
     }
 
-    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=3)) as session:
+    session_timeout = _calculate_session_timeout()
+
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=session_timeout)
+    ) as session:
         # Both Infrastructure and Logging require a "LICENSE_KEY" environment variable.
         # In order to send data to the Infrastructure Pipeline, the customer doesn't need
         # to do anything. To disable it, they'll set "INFRA_ENABLED" to "false".
@@ -219,7 +257,13 @@ async def _send_log_entry(log_entry, context):
                 requests.append(
                     _send_payload(_get_logging_request_creator(payload), session)
                 )
-        return await asyncio.gather(*requests)
+
+        logger.debug("Sending data to New Relic.....")
+        ini = time.perf_counter()
+        result = await asyncio.gather(*requests)
+        elapsed_millis = (time.perf_counter() - ini) * 1000
+        logger.debug(f"Time elapsed to send to New Relic: {elapsed_millis:0.2f}ms")
+        return result
 
 
 async def _send_payload(request_creator, session, retry=False):
@@ -229,13 +273,19 @@ async def _send_payload(request_creator, session, retry=False):
             session, req.get_full_url(), req.data, req.headers
         )
     except MaxRetriesException as e:
-        print("Retry limit reached. Failed to send log entry.")
+        logger.error("Retry limit reached. Failed to send log entry.")
         if retry:
             raise e
     except BadRequestException as e:
-        print(e)
+        logger.error(e)
+    except asyncio.TimeoutError as e:
+        logger.error("Session timed out. Failed to send log entry.")
+        raise e
+    except Exception as e:
+        logger.error(f"Error occurred: {e}")
+        raise e
     else:
-        print("Log entry sent. Response code: {}. url: {}".format(status, url))
+        logger.info("Log entry sent. Response code: {}. url: {}".format(status, url))
         return status
 
 
@@ -408,6 +458,18 @@ def _get_logging_request_creator(payload, ingest_url=None, license_key=None):
     return create_request
 
 
+def _set_console_logging_level():
+    """
+    Determines whether or not debug logging should be enabled based on the env var.
+    Defaults to false.
+    """
+    if _debug_logging_enabled():
+        logger.setLevel(logging.DEBUG)
+        logger.debug("Enabled debug mode")
+    else:
+        logger.setLevel(logging.INFO)
+
+
 def _get_logging_endpoint(ingest_url=None):
     """
     Service url is determined by the lincese key's region.
@@ -506,6 +568,8 @@ def lambda_handler(event, context):
     function's configuration.
     """
 
+    _set_console_logging_level()
+
     # CloudWatch Log entries are compressed and encoded in Base64
     event_data = b64decode(event["awslogs"]["data"])
     log_entry_str = gzip.decompress(event_data).decode("utf-8")
@@ -513,18 +577,17 @@ def lambda_handler(event, context):
 
     # output additional helpful info if debug logging is enabled
     # not enabled by default since parsing into json might be slow
-    if _debug_logging_enabled():
-        # calling '[0]' without a safety check looks sketchy, but Cloudwatch is never going
-        # to send us a log without at least one event
-        print(
-            "logGroup: {}, logStream: {}, timestamp: {}".format(
-                log_entry["logGroup"],
-                log_entry["logStream"],
-                datetime.datetime.fromtimestamp(
-                    log_entry["logEvents"][0]["timestamp"] / 1000.0
-                ),
-            )
+    # calling '[0]' without a safety check looks sketchy, but Cloudwatch is never going
+    # to send us a log without at least one event
+    logger.debug(
+        "logGroup: {}, logStream: {}, timestamp: {}".format(
+            log_entry["logGroup"],
+            log_entry["logStream"],
+            datetime.datetime.fromtimestamp(
+                log_entry["logEvents"][0]["timestamp"] / 1000.0
+            ),
         )
+    )
 
     asyncio.run(_send_log_entry(log_entry, context))
     # This makes it possible to chain this CW log consumer with others using a success destination

--- a/template.yaml
+++ b/template.yaml
@@ -43,6 +43,10 @@ Parameters:
     Type: String
     Description: IAM Role PermissionsBoundary (optional)
     Default: ''
+  DebugLoggingEnabled:
+    Type: String
+    Description: A boolean to determine if you want to output debug messages in the CloudWatch console
+    Default: "false"
 
 Conditions:
   NoRole: !Equals ['', !Ref FunctionRole]
@@ -83,6 +87,7 @@ Resources:
           LICENSE_KEY: !Ref NRLicenseKey
           LOGGING_ENABLED: !Ref NRLoggingEnabled
           INFRA_ENABLED: !Ref NRInfraLogging
+          DEBUG_LOGGING_ENABLED: !Ref DebugLoggingEnabled
   NewRelicLogIngestionFunction:
     Type: AWS::Serverless::Function
     Condition: NoRole
@@ -103,6 +108,7 @@ Resources:
           LICENSE_KEY: !Ref NRLicenseKey
           LOGGING_ENABLED: !Ref NRLoggingEnabled
           INFRA_ENABLED: !Ref NRInfraLogging
+          DEBUG_LOGGING_ENABLED: !Ref DebugLoggingEnabled
   LambdaInvokePermissionNoCap:
     Type: AWS::Lambda::Permission
     Condition: NoCap

--- a/test/log_ingestion_test.py
+++ b/test/log_ingestion_test.py
@@ -12,7 +12,7 @@ from test.mock_http_response import MockHttpResponse
 from test.aws_log_events import AwsLogEvents
 
 import asyncio
-from asynctest import CoroutineMock
+from asynctest import CoroutineMock, MagicMock
 
 US_URL = "https://log-api.newrelic.com/log/v1"
 EU_URL = "https://log-api.eu.newrelic.com/log/v1"
@@ -58,6 +58,22 @@ def event_loop():
 def mock_aio_post():
     with patch("aiohttp.ClientSession.post", new=CoroutineMock()) as mocked_aio_post:
         yield mocked_aio_post
+
+
+class AsyncContextManagerMock(MagicMock):
+    async def __aenter__(self):
+        return self.aenter
+
+    async def __aexit__(self, *args):
+        pass
+
+
+@pytest.fixture
+def mock_aio_session():
+    with patch(
+        "aiohttp.ClientSession", new=AsyncContextManagerMock()
+    ) as mocked_aio_session:
+        yield mocked_aio_session
 
 
 @patch.dict(
@@ -441,6 +457,69 @@ def test_when_first_two_calls_fail_code_should_retry(mock_aio_post):
     assert mock_aio_post.call_count == 3
 
 
+def test_session_duration_properly_calculated():
+    # Mock function configuration
+    function.MAX_RETRIES = 3
+    function.INITIAL_BACKOFF = 1
+    function.BACKOFF_MULTIPLIER = 2
+    function.INDIVIDUAL_REQUEST_TIMEOUT_DURATION = 3
+    function.SESSION_MAX_PROCESSING_TIME = 1
+
+    """
+    Diagram of performed calls:
+        - Call 0: 3s
+        - Backoff 0: 1s (initial)
+        - Call 1: 3s
+        - Backoff 1: 1 * 2s (initial * multiplier)
+        - Call 2: 3s
+        - session_max_processing_time: 1s
+        TOTAL: 8s
+    """
+    expected_max_session_time = 13
+
+    assert function._calculate_session_timeout() == expected_max_session_time
+
+
+def test_when_session_timeouts_exception_should_be_raised(mock_aio_session):
+    expected_message = "timeout_in_session"
+    mock_aio_session.side_effect = asyncio.TimeoutError(expected_message)
+    event = aws_log_events.create_aws_event(["Test Message 1"])
+
+    with pytest.raises(asyncio.TimeoutError) as excinfo:
+        function.lambda_handler(event, context)
+        pytest.fail("TimeoutError should have been raised by the ClientSession")
+
+    assert expected_message == str(excinfo.value)
+
+
+def test_when_exception_is_thrown_it_should_be_raised(mock_aio_session):
+    expected_message = "unexpected_exception_in_session"
+    mock_aio_session.side_effect = IOError(expected_message)
+    event = aws_log_events.create_aws_event(["Test Message 1"])
+
+    with pytest.raises(IOError) as excinfo:
+        function.lambda_handler(event, context)
+        pytest.fail(
+            "An unexpected exception should have been raised by the ClientSession"
+        )
+
+    assert expected_message == str(excinfo.value)
+
+
+def test_when_first_call_timeouts_code_should_retry(mock_aio_post):
+    # First two calls timeout, and then third succeeds
+    mock_aio_post.side_effect = [
+        aio_post_timeout(),
+        aio_post_timeout(),
+        aio_post_response(),
+    ]
+    event = aws_log_events.create_aws_event(["Test Message 1"])
+
+    function.lambda_handler(event, context)
+
+    assert mock_aio_post.call_count == 3
+
+
 def test_logs_have_logstream_and_loggroup(mock_aio_post):
     mock_aio_post.return_value = aio_post_response()
     message = "Test Message 1"
@@ -506,8 +585,12 @@ def test_lambda_request_ids_are_extracted(mock_aio_post):
     assert messages[4]["attributes"]["aws"]["lambda_request_id"] == expected_request_id2
 
 
-async def aio_post_response():
+def aio_post_response():
     return MockHttpResponse("", 202)
+
+
+def aio_post_timeout():
+    return asyncio.TimeoutError()
 
 
 def urlopen_error_response():


### PR DESCRIPTION
# Description
A customer notified us that the retry mechanism was not properly considering `TimeoutError`s, and even [opened a ticket](https://github.com/newrelic/aws-log-ingestion/issues/36) suggesting a solution. After inspecting the issue, we found that what was really performing the timeout was the `ClientSession` established for the whole lambda execution, which was set to tool low (3 seconds, _I wonder if it was meant to be 30 instead_). This PR fixes this issue by:
- Defining a timeout of 3 seconds for **individual POST requests**
- Defining a session timeout which is the sum of the expected individual POST requests (assuming the worst case of having a timeout in each of them), the backoffs between them and an additional time buffer of 1 second, to account for the processing time needed to create the payloads/requests.
- The customer also complained that it was rather difficult to debug what was failing of our lambda, so we added a debug mode that enables log.debug statements when retries are performed, as well as providing more details on the errors taking place.

# Related ticket(s)
https://newrelic.atlassian.net/browse/LOGGING-4864
https://newrelic.atlassian.net/browse/LOGGING-4700

# Tests
- The PR includes new unit tests for the added/modified functionalities.
- Manual tests have been performed in AWS lambda, using a fake API introducing controlled timeouts.