### PR TITLE
Support multiple environments: parameterize Lambda name and NR_TAGS

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -2,6 +2,10 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: Sends log data from CloudWatch Logs to New Relic Infrastructure (Cloud integrations) and New Relic Logging
 Parameters:
+  FunctionNameSuffix:
+    Type: String
+    Description: Suffix for the New Relic Log Ingestion Lambda function name
+    Default: ''
   NRLicenseKey:
     Type: String
     Description: Your NewRelic license key.
@@ -74,7 +78,10 @@ Resources:
       CodeUri: src/
       Description: Sends log data from CloudWatch Logs to New Relic Infrastructure (Cloud integrations) and New Relic Logging
       Handler: function.lambda_handler
-      FunctionName: newrelic-log-ingestion
+      FunctionName: !Join
+        - ""
+        - - newrelic-log-ingestion
+          - !Ref FunctionNameSuffix
       MemorySize:
         Ref: MemorySize
       Runtime: python3.7
@@ -96,7 +103,10 @@ Resources:
       CodeUri: src/
       Description: Sends log data from CloudWatch Logs to New Relic Infrastructure (Cloud integrations) and New Relic Logging
       Handler: function.lambda_handler
-      FunctionName: newrelic-log-ingestion
+      FunctionName: !Join
+        - ""
+        - - newrelic-log-ingestion
+          - !Ref FunctionNameSuffix
       MemorySize:
         Ref: MemorySize
       Runtime: python3.7

--- a/template.yaml
+++ b/template.yaml
@@ -17,6 +17,13 @@ Parameters:
     AllowedValues:
       - 'True'
       - 'False'
+  NRTags:
+    Type: String
+    Description: |
+      New Relic Logs tags to apply to each log line sent. A tag is a key value pair. Multiple tags can be specified.
+      Key and value are colon delimited. Multiple key value pairs are semi-colon delimited.
+      e.g. env:prod;team:myTeam
+    Default: ''
   NRInfraLogging:
     Type: String
     Description: Determines if logs are forwarded to New Relic Infrastructure
@@ -95,6 +102,7 @@ Resources:
           LOGGING_ENABLED: !Ref NRLoggingEnabled
           INFRA_ENABLED: !Ref NRInfraLogging
           DEBUG_LOGGING_ENABLED: !Ref DebugLoggingEnabled
+          NR_TAGS: !Ref NRTags
   NewRelicLogIngestionFunction:
     Type: AWS::Serverless::Function
     Condition: NoRole
@@ -119,6 +127,7 @@ Resources:
           LOGGING_ENABLED: !Ref NRLoggingEnabled
           INFRA_ENABLED: !Ref NRInfraLogging
           DEBUG_LOGGING_ENABLED: !Ref DebugLoggingEnabled
+          NR_TAGS: !Ref NRTags
   LambdaInvokePermissionNoCap:
     Type: AWS::Lambda::Permission
     Condition: NoCap


### PR DESCRIPTION
This PR adds support for deploying multiple New Relic log ingestion lambdas in the same AWS account/region (by adding a Lambda function name suffix parameter in SAM). Before this change it was not possible to have multiple environments of the Lambda because the name of the Lambda was a static string in the SAM template; Lambda names must be unique in every AWS account/region so the Serverless Application Repository-managed lambda could only be deployed once. This PR also adds a SAM parameter for NR_TAGS to be able to configure New Relic Logs tags during the deploy of each of those  Lambdas.

The use case for this has multiple aspects:
- to have separate New Relic log ingestion lambdas for different environments in the same AWS account/region in order to isolate the logging infrastructure for those environments from potential deployment/concurrency issues and allow testing of new features in a test environment
- to be able to vary the New Relic Logs tags on each of those separate lambdas, for example to identify the environment of an application sending logs to New Relic