### PR TITLE
Set service_name from Log Group and hostname from Log Stream

### DIFF
--- a/src/function.py
+++ b/src/function.py
@@ -526,6 +526,8 @@ def _package_log_payload(data):
                         "logStream": entry["logStream"],
                         "logGroup": entry["logGroup"],
                     },
+                    "service_name": entry["logGroup"].split("/")[-1],
+                    "hostname": entry["logStream"].split("/")[-1].split("]")[-1],
                 }
             },
             "logs": log_messages,


### PR DESCRIPTION
This PR uses the name of the CloudWatch Log Group and Log Stream to set the Service Name and hostname attributes in New Relic Logs. This is useful for applications that do not set those in their own logs.

Details:
- New Relic Logs attribute `service_name` will be set to the CloudWatch Log Group (trailing portion `/` delimited), and 
- New Relic Logs attribute `hostname` will be set to the trailing portion of the CloudWatch Log Stream (`/` or `]` delimited, the ECS task ID for ECS logs or identifier for an instance of a Lambda).

Without this change, both of those fields are N/A in New Relic Logs if the application is not setting them in the log message.