### PR TITLE
fix: Allow custom env var value delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ To forward data to New Relic you need a [New Relic License Key](https://docs.new
 
 To install and configure the New Relic Cloudwatch Logs Lambda, [see our documentation](https://docs.newrelic.com/docs/logs/enable-logs/enable-logs/aws-cloudwatch-plugin-logs).
 
+Additional notes:
+* Some users in UTF-8 environments have reported difficulty with defining strings of `NR_TAGS` delimited by the semicolon `;` character. If this applies to you, you can set an alternative delimiter character as the value of `NR_ENV_DELIMITER`, and separate your `NR_TAGS` with that. 
+
 ## Manual Deployment
 
 If your organization restricts access to deploy via SAR, follow these steps below

--- a/src/function.py
+++ b/src/function.py
@@ -21,7 +21,7 @@ It expects to be invoked based on CloudWatch Logs streams.
 New Relic's license key must be encrypted using KMS following these
 instructions:
 
-1. After creating te Lambda based on the Blueprint, select it and open the
+1. After creating the Lambda based on the Blueprint, select it and open the
 Environment Variables section.
 
 2. Check that the "LICENSE_KEY" environment variable if properly filled-in.
@@ -323,10 +323,11 @@ def _get_newrelic_tags(payload):
     e.g. env:prod;team:myTeam
     """
     nr_tags_str = os.getenv("NR_TAGS", "")
+    nr_delimiter = os.getenv("NR_ENV_DELIMITER", ";")
     if nr_tags_str:
         nr_tags = dict(
             item.split(":")
-            for item in nr_tags_str.split(";")
+            for item in nr_tags_str.split(nr_delimiter)
             if not item.startswith(tuple(["aws:", "plugin:"]))
         )
         payload[0]["common"]["attributes"].update(nr_tags)


### PR DESCRIPTION
Users in some language regions were unable to delimit NR_TAGS with the semicolon character. This PR allows a custom NR_TAGS delimiter users can define with the NR_ENV_DELIMITER env var. 

Signed-off-by: mrickard <maurice@mauricerickard.com>