### PR TITLE
Make nr_tags optional

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -30,6 +30,7 @@ variable "nr_tags" {
   type        = string
   description = "Additional tags added to the logs"
   sensitive   = false
+  default     = null
 }
 
 variable "lambda_archive" {


### PR DESCRIPTION
The documentation states that the field nr_tags is optional. But the
terraform code requires you to specify the field.
Documentation: https://docs.newrelic.com/docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs/

Error without setting the nr_tags field:
```
➜ terraform plan
╷
│ Error: Missing required argument
│
│   on main.tf line 21, in module "newrelic_log_ingestion":
│   21: module "newrelic_log_ingestion" {
│
│ The argument "nr_tags" is required, but no definition was found.
```

This commit adds a default value, so that the field is actually optional
as stated in the documentation.