### PR TITLE
Make `Metadata.SemanticVersion` match latest release

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -62,7 +62,7 @@ Metadata:
     LicenseUrl: LICENSE
     ReadmeUrl: README.md
     HomePageUrl: https://github.com/newrelic/aws-log-ingestion
-    SemanticVersion: 2.6.4
+    SemanticVersion: 2.7.0
     SourceCodeUrl: https://github.com/newrelic/aws-log-ingestion
 
 Resources:


### PR DESCRIPTION
`Metdata.SemanticVersion` needs to be updated to latest in order to be able to publish https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-template-publishing-applications.html