### PR TITLE
feat: Allow installing the integration more than once per account and region

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-log-ingestion"
-version = "2.7.1"
+version = "2.7.2"
 description = ""
 authors = ["New Relic <serverless@newrelic.com>"]
 license = "Apache 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-log-ingestion"
-version = "2.7.2"
+version = "2.8.0"
 description = ""
 authors = ["New Relic <serverless@newrelic.com>"]
 license = "Apache 2.0"

--- a/template.yaml
+++ b/template.yaml
@@ -62,7 +62,7 @@ Metadata:
     LicenseUrl: LICENSE
     ReadmeUrl: README.md
     HomePageUrl: https://github.com/newrelic/aws-log-ingestion
-    SemanticVersion: 2.7.1
+    SemanticVersion: 2.7.2
     SourceCodeUrl: https://github.com/newrelic/aws-log-ingestion
 
 Resources:
@@ -74,7 +74,7 @@ Resources:
       CodeUri: src/
       Description: Sends log data from CloudWatch Logs to New Relic Infrastructure (Cloud integrations) and New Relic Logging
       Handler: function.lambda_handler
-      FunctionName: newrelic-log-ingestion
+      FunctionName: !Join ['-', ['newrelic-log-ingestion', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
       MemorySize:
         Ref: MemorySize
       Runtime: python3.9
@@ -96,7 +96,7 @@ Resources:
       CodeUri: src/
       Description: Sends log data from CloudWatch Logs to New Relic Infrastructure (Cloud integrations) and New Relic Logging
       Handler: function.lambda_handler
-      FunctionName: newrelic-log-ingestion
+      FunctionName: !Join ['-', ['newrelic-log-ingestion', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
       MemorySize:
         Ref: MemorySize
       Runtime: python3.9

--- a/template.yaml
+++ b/template.yaml
@@ -62,7 +62,7 @@ Metadata:
     LicenseUrl: LICENSE
     ReadmeUrl: README.md
     HomePageUrl: https://github.com/newrelic/aws-log-ingestion
-    SemanticVersion: 2.7.2
+    SemanticVersion: 2.8.0
     SourceCodeUrl: https://github.com/newrelic/aws-log-ingestion
 
 Resources:


### PR DESCRIPTION
Currently, it is not possible to install the integration multiple times for the same account and region. This is because the name of the function is always the same (`newrelic-log-ingestion`) every time the application is deployed. AWS does not allow having two or more functions with the same name per account and region.

With the changes made in the `template.yml` file, now the function name will take as suffix twelve hexadecimal characters extracted from the last part of the `AWS::StackId` pseudo parameter linked to the deployment. For example:
`newrelic-log-ingestion-0a81f551ce24`. In this way, it will be possible to deploy the application more than once, since the function name will be always different from one deployment to another.
 