### PR TITLE
fix: downgraded python version to 3.10 in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.10"]
         poetry-version: ["1.4"]
         os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary 
* Downgraded Python version to 3.10 in `release.yml` because `sam` CLI does not support Python 3.11
