### PR TITLE
Bump python runtime 3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           poetry run sam validate
           poetry run sam build
           poetry run sam package --s3-bucket nr-serverless-applications --output-template-file packaged.yaml
-          poetry run sam publish --region us-east-1 --template packaged.yaml
+          sam publish --region us-east-1 --template packaged.yaml
 
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary 
* Removed `poetry` from `sam publish` command in release GitHub action.