### PR TITLE
Added logic to use new relic license from multiple sources

### DIFF
--- a/src/function.py
+++ b/src/function.py
@@ -325,9 +325,9 @@ def _get_license_key(license_key=None):
     license_key_source = _get_license_key_source()
 
     if license_key_source == "ssm":
-        return _get_license_key_from_ssm(license_key)
+        return _get_license_key_from_ssm(os.getenv("LICENSE_KEY", ""))
     elif license_key_source == "secret_manager":
-        return _get_license_key_from_secret_manager(license_key)
+        return _get_license_key_from_secret_manager(os.getenv("LICENSE_KEY", ""))
     
     return os.getenv("LICENSE_KEY", "")
     
@@ -341,6 +341,9 @@ def _get_license_key_from_secret_manager(secret_name):
     Returns:
     - The value of the secret if found, otherwise None.
     """
+    if not secret_name:
+        return ""
+
     # Create a Secrets Manager client
     client = boto3.client('secretsmanager')
 
@@ -372,6 +375,8 @@ def _get_license_key_from_ssm(parameter_path):
     - The value of the parameter if found, otherwise None.
     """
     # Create an SSM client
+    if not parameter_path:
+        return ""
     client = boto3.client('ssm')
 
     try:

--- a/src/function.py
+++ b/src/function.py
@@ -319,8 +319,8 @@ def _get_license_key(license_key=None):
     """
     This functions gets New Relic's license key from env vars.
     """
-    if not license_key:
-        return ""
+    if license_key:
+        return license_key
 
     license_key_source = _get_license_key_source()
 

--- a/src/function.py
+++ b/src/function.py
@@ -313,7 +313,7 @@ def _get_license_key_source():
     This function returns the source of the license key.
     LICENSE_KEY_SRC must be one of 'environment_var', 'ssm', or 'secret_manager'."
     """
-    return os.getenv("LICENSE_KEY_SRC", "true").lower() == "true"
+    return os.getenv("LICENSE_KEY_SRC", "environment_var")
 
 def _get_license_key(license_key=None):
     """

--- a/terraform.tf
+++ b/terraform.tf
@@ -14,6 +14,15 @@ variable "nr_license_key" {
   sensitive   = true
 }
 
+variable "nr_license_key_source" {
+  type        = string
+  description = "The source of the NewRelic license key. Must be one of 'environment_var', 'ssm', or 'secret_manager'."
+  validation {
+    condition     = contains(["environment_var", "ssm", "secret_manager"], var.nr_license_key_source)
+    error_message = "The nr_license_key_source must be one of 'environment_var', 'ssm', or 'secret_manager'."
+  }
+}
+
 variable "nr_logging_enabled" {
   type        = bool
   description = "Determines if logs are forwarded to New Relic Logging"
@@ -191,6 +200,7 @@ resource "aws_lambda_function" "ingestion_function" {
   environment {
     variables = {
       LICENSE_KEY     = var.nr_license_key
+      LICENSE_KEY_SRC = var.nr_license_key_source
       LOGGING_ENABLED = var.nr_logging_enabled ? "True" : "False"
       INFRA_ENABLED   = var.nr_infra_logging ? "True" : "False"
       NR_TAGS         = var.nr_tags

--- a/terraform.tf
+++ b/terraform.tf
@@ -17,6 +17,7 @@ variable "nr_license_key" {
 variable "nr_license_key_source" {
   type        = string
   description = "The source of the NewRelic license key. Must be one of 'environment_var', 'ssm', or 'secret_manager'."
+  default     = "environment_var"
   validation {
     condition     = contains(["environment_var", "ssm", "secret_manager"], var.nr_license_key_source)
     error_message = "The nr_license_key_source must be one of 'environment_var', 'ssm', or 'secret_manager'."

--- a/test/log_ingestion_test.py
+++ b/test/log_ingestion_test.py
@@ -4,6 +4,8 @@ import os
 import pprint
 import pytest
 import uuid
+import boto3
+from botocore.exceptions import ClientError
 
 from base64 import b64decode
 from mock import patch
@@ -22,6 +24,9 @@ OTHER_URL = "http://some-other-endpoint/logs/v1"
 timestamp = 1548935491174
 logging_enabled = "true"
 infra_enabled = "false"  # These tests just test logging
+lisence_key_source_env_var = "environment_var"
+lisence_key_source_ssm = "ssm"
+lisence_key_source_secrets_manager = "secrets_manager"
 license_key = "testlicensekey"
 license_key_eu = "eutestlicensekey"
 log_group_name = "/aws/lambda/sam-node-test-dev-triggered"
@@ -74,6 +79,121 @@ def mock_aio_session():
         "aiohttp.ClientSession", new=AsyncContextManagerMock()
     ) as mocked_aio_session:
         yield mocked_aio_session
+
+@patch.dict(
+    os.environ,
+    {
+     "LICENSE_KEY": license_key, 
+     "LICENSE_KEY_SRC": lisence_key_source_env_var
+     },
+    clear=True,
+)
+def test_get_license_key_from_env_var():
+    assert function._get_license_key() == license_key
+
+@patch.dict(
+    os.environ,
+    {
+     "LICENSE_KEY": license_key, 
+     "LICENSE_KEY_SRC": lisence_key_source_secrets_manager
+     },
+    clear=True,
+)
+@patch('src.function._get_license_key_from_secret_manager')
+def test_get_license_from_key_secret_manager(mock_get_license_key_from_secret_manager):
+    mock_get_license_key_from_secret_manager.return_value = license_key
+    
+    assert function._get_license_key() == license_key
+
+@patch.dict(
+    os.environ,
+    {
+     "LICENSE_KEY": license_key, 
+     "LICENSE_KEY_SRC": lisence_key_source_ssm
+     },
+    clear=True,
+)
+@patch('src.function._get_license_key_from_ssm')
+def test_get_license_from_key_ssm(mock_get_license_key_from_ssm):
+    mock_get_license_key_from_ssm.return_value = license_key
+    assert function._get_license_key() == license_key
+
+
+@pytest.fixture
+def mock_boto3_client():
+    with patch.object(boto3, 'client') as mock:
+        yield mock
+
+
+def test_get_license_key_from_secret_manager_success(mock_boto3_client):
+    # Mock the Secrets Manager client response for a successful secret retrieval
+    mock_secret_value = {"SecretString": "my-secret-value"}
+    mock_boto3_client.return_value.get_secret_value.return_value = mock_secret_value
+
+    secret_name = "my-secret"
+    expected_secret_value = "my-secret-value"
+    actual_secret_value = function._get_license_key_from_secret_manager(secret_name)
+
+    mock_boto3_client.assert_called_once_with('secretsmanager')
+    mock_boto3_client.return_value.get_secret_value.assert_called_once_with(SecretId=secret_name)
+    assert actual_secret_value == expected_secret_value
+
+def test_get_license_key_from_secret_manager_not_found(mock_boto3_client):
+    # Mock the Secrets Manager client to raise a ClientError for a missing secret
+    mock_boto3_client.return_value.get_secret_value.side_effect = ClientError(
+        error_response={'Error': {'Code': 'ResourceNotFoundException'}},
+        operation_name='GetSecretValue'
+    )
+
+    secret_name = "non-existent-secret"
+    expected_secret_value = None
+    actual_secret_value = function._get_license_key_from_secret_manager(secret_name)
+
+    mock_boto3_client.assert_called_once_with('secretsmanager')
+    mock_boto3_client.return_value.get_secret_value.assert_called_once_with(SecretId=secret_name)
+    assert actual_secret_value == expected_secret_value
+
+def test_get_license_key_from_secret_manager_empty_secret_name():
+    secret_name = ""
+    expected_secret_value = ""
+    actual_secret_value = function._get_license_key_from_secret_manager(secret_name)
+
+    assert actual_secret_value == expected_secret_value
+
+def test_get_license_key_from_ssm_success(mock_boto3_client):
+    # Mock the SSM client response for a successful parameter retrieval
+    mock_parameter_value = {"Parameter": {"Value": "my-parameter-value"}}
+    mock_boto3_client.return_value.get_parameter.return_value = mock_parameter_value
+
+    parameter_path = "my-parameter-path"
+    expected_parameter_value = "my-parameter-value"
+    actual_parameter_value = function._get_license_key_from_ssm(parameter_path)
+
+    mock_boto3_client.assert_called_once_with('ssm')
+    mock_boto3_client.return_value.get_parameter.assert_called_once_with(Name=parameter_path, WithDecryption=True)
+    assert actual_parameter_value == expected_parameter_value
+
+def test_get_license_key_from_ssm_not_found(mock_boto3_client):
+    # Mock the SSM client to raise a ClientError for a missing parameter
+    mock_boto3_client.return_value.get_parameter.side_effect = ClientError(
+        error_response={'Error': {'Code': 'ParameterNotFound'}},
+        operation_name='GetParameter'
+    )
+
+    parameter_path = "non-existent-parameter-path"
+    expected_parameter_value = ""
+    actual_parameter_value = function._get_license_key_from_ssm(parameter_path)
+
+    mock_boto3_client.assert_called_once_with('ssm')
+    mock_boto3_client.return_value.get_parameter.assert_called_once_with(Name=parameter_path, WithDecryption=True)
+    assert actual_parameter_value == expected_parameter_value
+
+def test_get_license_key_from_ssm_empty_parameter_path():
+    parameter_path = ""
+    expected_parameter_value = ""
+    actual_parameter_value = function._get_license_key_from_ssm(parameter_path)
+
+    assert actual_parameter_value == expected_parameter_value
 
 
 @patch.dict(


### PR DESCRIPTION
### Overview

> This PR introduces the functionality to support fetching New Relic license keys from multiple sources: environment variables, AWS Systems Manager (SSM) Parameter Store, and AWS Secrets Manager. The changes include updates to the Python source code, Terraform configuration, and corresponding unit tests to accommodate the new key sources.


### Benefits

- Flexibility: Allows configuring New Relic license keys from multiple secure sources, enhancing the flexibility and security of the deployment.
- Security: Supports the use of AWS Secrets Manager and SSM Parameter Store, which are secure and managed services for storing sensitive information.
- Testing: Comprehensive unit tests ensure the reliability of the new functionality and cover various scenarios and edge cases.

### Testing

- Executed unit tests to verify that the New Relic license keys are correctly fetched from environment variables, Secrets Manager, and SSM Parameter Store.
- Tested the error handling for missing or invalid secrets/parameters.