### PR TITLE
feat: added support for log format using NEW_RELIC_FORMAT_LOGS.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         python-version: ["3.11"]
         poetry-version: ["1.4"]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
       matrix:
         python-version: ["3.11"]
         poetry-version: ["1.4"]
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "2.9.5"
 description = ""
 authors = ["New Relic <serverless@newrelic.com>"]
 license = "Apache 2.0"
+package-mode= false
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/src/function.py
+++ b/src/function.py
@@ -182,6 +182,15 @@ def _filter_log_lines(log_entry):
     for event in log_entry["logEvents"]:
         message = event["message"]
         if REPORT_PATTERN.match(message) or _is_lambda_message(message):
+            id, timestamp, message = event["id"], event["timestamp"], event["message"]
+            reconstructed_message = message.split('\t')
+            if len(reconstructed_message) >= 4:
+                message = reconstructed_message[3]
+                event = {
+                    "id": id,
+                    "timestamp": timestamp,
+                    "message": message
+                }
             final_log_events.append(event)
 
     ret = log_entry.copy()

--- a/src/function.py
+++ b/src/function.py
@@ -181,7 +181,6 @@ def processEventPayload(event):
     id, timestamp, message = event["id"], event["timestamp"], event["message"]
     reconstructed_message = message.split('\t')
     if len(reconstructed_message) >= 4:
-        
         message = reconstructed_message[3]
         event = {
             "id": id,

--- a/src/function.py
+++ b/src/function.py
@@ -180,14 +180,10 @@ def format_agent_logs(event):
     Processes event payload for all formats.
     """
     id, timestamp, message = event["id"], event["timestamp"], event["message"]
-    reconstructed_message = message.split('\t')
+    reconstructed_message = message.split("\t")
     if len(reconstructed_message) == 4:
         message = reconstructed_message[3]
-        event = {
-            "id": id,
-            "timestamp": timestamp,
-            "message": message
-        }
+        event = {"id": id, "timestamp": timestamp, "message": message}
     return event
 
 

--- a/src/function.py
+++ b/src/function.py
@@ -188,7 +188,6 @@ def format_agent_logs(event):
             "timestamp": timestamp,
             "message": message
         }
-    
     return event
 
 


### PR DESCRIPTION
**Detail**: The log-ingestion Lambda was unable to process the unique payload formats generated by .NET Lambda functions, leading to integration issues with New Relic. These payloads differed from those initially supported, causing disruptions in data parsing and instrumentation.

**Solution**: This PR updates the log-ingestion lambda function to support the specific .NET payload formats, resolving the compatibility issue. By implementing the necessary changes, .NET Lambda functions can now integrate seamlessly with New Relic, restoring proper functionality and instrumentation.