### PR TITLE
chore: data.aws_region.current.name is being deprecated for data.aws_…

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -93,7 +93,7 @@ data "aws_region" "current" {}
 locals {
   aws_account_id = data.aws_caller_identity.current.account_id
   aws_partition  = data.aws_partition.current.partition
-  aws_region     = data.aws_region.current.name
+  aws_region     = data.aws_region.current.region
   archive_name   = var.lambda_archive
   archive_folder = dirname(local.archive_name)
   tags = merge(


### PR DESCRIPTION
Fixing deprecation warning in Terraform.

[Documentation 
](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region)
```
new_relic_s3_ingestion.newrelic_log_ingestion/terraform.tf line 96, in locals:
│   96:   aws_region     = data.aws_region.current.name
│ 
│ The attribute "name" is deprecated. Refer to the provider documentation for
│ details.
│ 
```