### PR TITLE
NR-560731 Add Japan (JP) region endpoint support for log ingestion

### DIFF
--- a/src/function.py
+++ b/src/function.py
@@ -106,8 +106,10 @@ class EntryType(Enum):
 INGEST_SERVICE_VERSION = "v1"
 US_LOGGING_ENDPOINT = "https://log-api.newrelic.com/log/v1"
 EU_LOGGING_ENDPOINT = "https://log-api.eu.newrelic.com/log/v1"
+JP_LOGGING_ENDPOINT = "https://log-api.jp.newrelic.com/log/v1"
 US_INFRA_ENDPOINT = "https://cloud-collector.newrelic.com"
 EU_INFRA_ENDPOINT = "https://cloud-collector.eu01.nr-data.net"
+JP_INFRA_ENDPOINT = "https://cloud-collector.jp01.nr-data.net"
 INFRA_INGEST_SERVICE_PATHS = {
     EntryType.LAMBDA: "/aws/lambda",
     EntryType.VPC: "/aws/vpc",
@@ -424,9 +426,12 @@ def _get_infra_endpoint():
     """
     if "NR_INFRA_ENDPOINT" in os.environ:
         return os.environ["NR_INFRA_ENDPOINT"]
-    return (
-        EU_INFRA_ENDPOINT if _get_license_key().startswith("eu") else US_INFRA_ENDPOINT
-    )
+    license_key = _get_license_key()
+    if license_key.startswith("eu"):
+        return EU_INFRA_ENDPOINT
+    elif license_key.startswith("jp"):
+        return JP_INFRA_ENDPOINT
+    return US_INFRA_ENDPOINT
 
 
 def _split_infra_payload(data):
@@ -495,11 +500,12 @@ def _get_logging_endpoint(ingest_url=None):
         return ingest_url
     if "NR_LOGGING_ENDPOINT" in os.environ:
         return os.environ["NR_LOGGING_ENDPOINT"]
-    return (
-        EU_LOGGING_ENDPOINT
-        if _get_license_key().startswith("eu")
-        else US_LOGGING_ENDPOINT
-    )
+    license_key = _get_license_key()
+    if license_key.startswith("eu"):
+        return EU_LOGGING_ENDPOINT
+    elif license_key.startswith("jp"):
+        return JP_LOGGING_ENDPOINT
+    return US_LOGGING_ENDPOINT
 
 
 def _package_log_payload(data):

--- a/test/log_ingestion_test.py
+++ b/test/log_ingestion_test.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, AsyncMock
 
 US_URL = "https://log-api.newrelic.com/log/v1"
 EU_URL = "https://log-api.eu.newrelic.com/log/v1"
+JP_URL = "https://log-api.jp.newrelic.com/log/v1"
 OTHER_URL = "http://some-other-endpoint/logs/v1"
 
 
@@ -24,6 +25,7 @@ logging_enabled = "true"
 infra_enabled = "false"  # These tests just test logging
 license_key = "testlicensekey"
 license_key_eu = "eutestlicensekey"
+license_key_jp = "jptestlicensekey"
 log_group_name = "/aws/lambda/sam-node-test-dev-triggered"
 log_stream_name = "2019/01/31/[$LATEST]fe9b6a749a854acb95af7951c44a79e0"
 aws_log_events = AwsLogEvents(timestamp, log_group_name, log_stream_name)
@@ -109,6 +111,19 @@ def test_logging_can_override_nr_endpoint():
 )
 def test_logging_has_eu_nr_endpoint():
     assert function._get_logging_endpoint() == EU_URL
+
+
+@patch.dict(
+    os.environ,
+    {
+        "INFRA_ENABLED": infra_enabled,
+        "LOGGING_ENABLED": logging_enabled,
+        "LICENSE_KEY": license_key_jp,
+    },
+    clear=True,
+)
+def test_logging_has_jp_nr_endpoint():
+    assert function._get_logging_endpoint() == JP_URL
 
 
 def test_proper_headers_are_added(mock_aio_post):


### PR DESCRIPTION
Add JP-specific logging and infrastructure endpoints that route automatically when the license key starts with "jp", matching the  existing EU region pattern.                                                                                                                                                                         
                                                                                                                                                                                                      
  Changes:                                                                                                                                                                                            
  - Add JP_LOGGING_ENDPOINT (log-api.jp.newrelic.com)                                                                                                                                                 
  - Add JP_INFRA_ENDPOINT (cloud-collector.jp.nr-data.net)                                                                                                                                          
  - Update _get_infra_endpoint() and _get_logging_endpoint() to detect JP license keys                                                                                                                
  - Add test coverage for JP logging endpoint selection
<img width="1711" height="861" alt="Screenshot 2026-05-07 at 10 44 55 AM" src="https://github.com/user-attachments/assets/83ac4d47-5a23-4fdd-9d48-a2b892cf8389" />

JP Region Endpoint Routing - Verified                                                                                                                                                                        
 Deployed the Lambda to ap-northeast-1 with a jp-prefixed license key. Confirmed that the function correctly routes requests to the JP endpoints:                                                             
 - Infra: cloud-collector.jp.nr-data.net
 - Logging: log-api.jp.newrelic.com                                                                                                                                                                                          
 DNS resolution fails as expected since the JP endpoints are not yet provisioned. Once they go live, no code changes will be needed.
