### PR TITLE
NR-560731 Fix JP infra endpoint hostname from jp01 to jp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [tool.poetry]
 name = "aws-log-ingestion"
-version = "2.11.1"
+version = "2.11.2"
 description = ""
 authors = ["New Relic <serverless@newrelic.com>"]
 license = "Apache 2.0"
 package-mode= false
 
 [tool.poetry.dependencies]
-python = "^3.13"
-aiohttp = "^3.13.5"
+python = "^3.12"
+aiohttp = "^3.13.2"
 
 [tool.poetry.group.dev.dependencies]
 aws-sam-cli = "^1.118.0"
@@ -27,7 +27,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 88
-target-version = ['py313']
+target-version = ['py312']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/src/function.py
+++ b/src/function.py
@@ -121,7 +121,7 @@ LAMBDA_REQUEST_ID_REGEX = re.compile(
     r"(?P<request_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
 )
 
-LOGGING_LAMBDA_VERSION = "2.11.1"
+LOGGING_LAMBDA_VERSION = "2.11.2"
 LOGGING_PLUGIN_METADATA = {"type": "lambda", "version": LOGGING_LAMBDA_VERSION}
 
 

--- a/src/function.py
+++ b/src/function.py
@@ -109,7 +109,7 @@ EU_LOGGING_ENDPOINT = "https://log-api.eu.newrelic.com/log/v1"
 JP_LOGGING_ENDPOINT = "https://log-api.jp.newrelic.com/log/v1"
 US_INFRA_ENDPOINT = "https://cloud-collector.newrelic.com"
 EU_INFRA_ENDPOINT = "https://cloud-collector.eu01.nr-data.net"
-JP_INFRA_ENDPOINT = "https://cloud-collector.jp01.nr-data.net"
+JP_INFRA_ENDPOINT = "https://cloud-collector.jp.nr-data.net"
 INFRA_INGEST_SERVICE_PATHS = {
     EntryType.LAMBDA: "/aws/lambda",
     EntryType.VPC: "/aws/vpc",

--- a/template.yaml
+++ b/template.yaml
@@ -62,7 +62,7 @@ Metadata:
     LicenseUrl: LICENSE
     ReadmeUrl: README.md
     HomePageUrl: https://github.com/newrelic/aws-log-ingestion
-    SemanticVersion: 2.11.1
+    SemanticVersion: 2.11.2
     SourceCodeUrl: https://github.com/newrelic/aws-log-ingestion
 
 Resources:
@@ -77,7 +77,7 @@ Resources:
       FunctionName: !Join ['-', ['newrelic-log-ingestion', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
       MemorySize:
         Ref: MemorySize
-      Runtime: python3.13
+      Runtime: python3.12
       PermissionsBoundary: !If [ HasPermissionBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
       Role: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${FunctionRole}
       Timeout:
@@ -99,7 +99,7 @@ Resources:
       FunctionName: !Join ['-', ['newrelic-log-ingestion', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
       MemorySize:
         Ref: MemorySize
-      Runtime: python3.13
+      Runtime: python3.12
       PermissionsBoundary: !If [ HasPermissionBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
       Timeout:
         Ref: Timeout


### PR DESCRIPTION
- Fixed JP infra endpoint from `cloud-collector.jp01.nr-data.net` (non-existent) to `cloud-collector.jp.nr-data.net` 
  - Without this fix, any lambda using a JP license key fails to send infra data due to DNS resolution failure