### PR TITLE
NR-568858 Fix JP infra endpoint and bump version to 2.11.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-log-ingestion"
-version = "2.11.1"
+version = "2.11.2"
 description = ""
 authors = ["New Relic <serverless@newrelic.com>"]
 license = "Apache 2.0"

--- a/src/function.py
+++ b/src/function.py
@@ -109,7 +109,7 @@ EU_LOGGING_ENDPOINT = "https://log-api.eu.newrelic.com/log/v1"
 JP_LOGGING_ENDPOINT = "https://log-api.jp.newrelic.com/log/v1"
 US_INFRA_ENDPOINT = "https://cloud-collector.newrelic.com"
 EU_INFRA_ENDPOINT = "https://cloud-collector.eu01.nr-data.net"
-JP_INFRA_ENDPOINT = "https://cloud-collector.jp01.nr-data.net"
+JP_INFRA_ENDPOINT = "https://cloud-collector.jp.nr-data.net"
 INFRA_INGEST_SERVICE_PATHS = {
     EntryType.LAMBDA: "/aws/lambda",
     EntryType.VPC: "/aws/vpc",
@@ -121,7 +121,7 @@ LAMBDA_REQUEST_ID_REGEX = re.compile(
     r"(?P<request_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
 )
 
-LOGGING_LAMBDA_VERSION = "2.11.1"
+LOGGING_LAMBDA_VERSION = "2.11.2"
 LOGGING_PLUGIN_METADATA = {"type": "lambda", "version": LOGGING_LAMBDA_VERSION}
 
 

--- a/template.yaml
+++ b/template.yaml
@@ -62,7 +62,7 @@ Metadata:
     LicenseUrl: LICENSE
     ReadmeUrl: README.md
     HomePageUrl: https://github.com/newrelic/aws-log-ingestion
-    SemanticVersion: 2.11.1
+    SemanticVersion: 2.11.2
     SourceCodeUrl: https://github.com/newrelic/aws-log-ingestion
 
 Resources:


### PR DESCRIPTION
 -Fixed JP infra endpoint from `cloud-collector.jp01.nr-data.net` (non-existent) to `cloud-collector.jp.nr-data.net`
  - Without this fix, any lambda using a JP license key fails to send infra data due to DNS resolution failure
  - bumped the version to 2.11.2