### PR TITLE
fix: update JP logging endpoint to log-api.jp.nr-data.net

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-log-ingestion"
-version = "2.11.2"
+version = "2.11.3"
 description = ""
 authors = ["New Relic <serverless@newrelic.com>"]
 license = "Apache 2.0"

--- a/src/function.py
+++ b/src/function.py
@@ -106,7 +106,7 @@ class EntryType(Enum):
 INGEST_SERVICE_VERSION = "v1"
 US_LOGGING_ENDPOINT = "https://log-api.newrelic.com/log/v1"
 EU_LOGGING_ENDPOINT = "https://log-api.eu.newrelic.com/log/v1"
-JP_LOGGING_ENDPOINT = "https://log-api.jp.newrelic.com/log/v1"
+JP_LOGGING_ENDPOINT = "https://log-api.jp.nr-data.net/log/v1"
 US_INFRA_ENDPOINT = "https://cloud-collector.newrelic.com"
 EU_INFRA_ENDPOINT = "https://cloud-collector.eu01.nr-data.net"
 JP_INFRA_ENDPOINT = "https://cloud-collector.jp.nr-data.net"
@@ -121,7 +121,7 @@ LAMBDA_REQUEST_ID_REGEX = re.compile(
     r"(?P<request_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
 )
 
-LOGGING_LAMBDA_VERSION = "2.11.2"
+LOGGING_LAMBDA_VERSION = "2.11.3"
 LOGGING_PLUGIN_METADATA = {"type": "lambda", "version": LOGGING_LAMBDA_VERSION}
 
 

--- a/template.yaml
+++ b/template.yaml
@@ -62,7 +62,7 @@ Metadata:
     LicenseUrl: LICENSE
     ReadmeUrl: README.md
     HomePageUrl: https://github.com/newrelic/aws-log-ingestion
-    SemanticVersion: 2.11.2
+    SemanticVersion: 2.11.3
     SourceCodeUrl: https://github.com/newrelic/aws-log-ingestion
 
 Resources:

--- a/test/log_ingestion_test.py
+++ b/test/log_ingestion_test.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, AsyncMock
 
 US_URL = "https://log-api.newrelic.com/log/v1"
 EU_URL = "https://log-api.eu.newrelic.com/log/v1"
-JP_URL = "https://log-api.jp.newrelic.com/log/v1"
+JP_URL = "https://log-api.jp.nr-data.net/log/v1"
 OTHER_URL = "http://some-other-endpoint/logs/v1"
 
 


### PR DESCRIPTION
 ## Summary
  - Updated JP logging endpoint from `log-api.jp.newrelic.com/log/v1` to `log-api.jp.nr-data.net/log/v1`
  - Bumped version from 2.11.2 to 2.11.3

  ## Reason 
  The JP logging endpoint has been migrated to the `nr-data.net` domain. The previous `newrelic.com` domain will be deprecated for the JP region.

  ## Changes
  - `src/function.py` — updated `JP_LOGGING_ENDPOINT` and bumped `LOGGING_LAMBDA_VERSION` to 2.11.3
  - `pyproject.toml` — version bump to 2.11.3
  - `template.yaml` — version bump to 2.11.3