### PR TITLE
feat: support v1/v2-str/v2-dict NR_LAMBDA_MONITORING formats in _get_trace_id for standard W3C trace correlation

### DIFF
--- a/src/function.py
+++ b/src/function.py
@@ -520,7 +520,14 @@ def _package_log_payload(data):
 
     for log_event in log_events:
         if LAMBDA_NR_MONITORING_PATTERN.match(log_event["message"]):
-            trace_id = _get_trace_id(log_event["message"])
+            msg = log_event["message"]
+            if NEW_RELIC_FORMAT_LOGS:
+                # .NET Lambda runtime prefixes Console.WriteLine with timestamp\treqId\tinfo\t.
+                # Strip that prefix so _get_trace_id can parse the JSON payload.
+                parts = msg.split("\t")
+                if len(parts) == 4:
+                    msg = parts[3]
+            trace_id = _get_trace_id(msg)
 
         log_message = {
             "message": log_event["message"],
@@ -587,12 +594,21 @@ def _reconstruct_log_payload(common, logs):
 
 def _get_trace_id(message_str):
     """
-    message_str: str
-        message = "[
-            1,
-            \"NR_LAMBDA_MONITORING\",
-            \"base64.b64encode(gzip.compress(message)).decode("utf-8")\",
-        ]"
+    Extracts traceId from an NR_LAMBDA_MONITORING payload string.
+
+    Handles three payload formats produced by different NR agents:
+
+    v1 (Python, Node.js):
+        [1, "NR_LAMBDA_MONITORING", "<base64_gzip>"]
+        Decompressed payload: {"metadata": {...}, "data": {"analytic_event_data": ...}}
+
+    v2-str (.NET, Ruby, Go):
+        [2, "NR_LAMBDA_MONITORING", {metadata_dict}, "<base64_gzip>"]
+        Decompressed payload: {"analytic_event_data": ..., "span_event_data": ...}  (flat, no "data" wrapper)
+
+    v2-dict (Java NewRelicAgentJava):
+        [2, "NR_LAMBDA_MONITORING", {metadata_dict}, {data_dict}]
+        Payload at index 3 is already a plain JSON dict, not encoded.
     """
 
     def extract_trace_id(key):
@@ -605,8 +621,25 @@ def _get_trace_id(message_str):
     trace_id = ""
     try:
         message = json.loads(message_str)
-        data_str = gzip.decompress(b64decode(message[2])).decode("utf-8")
-        data = json.loads(data_str)["data"]
+        version = message[0]
+
+        if version == 1:
+            # v1: Python, Node.js — payload at index 2, wrapped in {"data": {...}}
+            data_str = gzip.decompress(b64decode(message[2])).decode("utf-8")
+            data = json.loads(data_str)
+            if "data" in data:
+                data = data["data"]
+        elif version == 2:
+            payload = message[3]
+            if isinstance(payload, str):
+                # v2-str: .NET, Ruby, Go — payload at index 3, base64+gzip, flat dict
+                data = json.loads(gzip.decompress(b64decode(payload)).decode("utf-8"))
+            else:
+                # v2-dict: Java (NewRelicAgentJava) — payload at index 3, already a plain dict
+                data = payload
+        else:
+            logger.debug(f"Unknown NR_LAMBDA_MONITORING version: {version}")
+            return trace_id
 
         trace_id = extract_trace_id("analytic_event_data")
         if trace_id:

--- a/src/function.py
+++ b/src/function.py
@@ -34,6 +34,7 @@ For more detailed documentation, check New Relic's documentation site:
 https://docs.newrelic.com/
 """
 
+import asyncio
 import datetime
 import gzip
 import json
@@ -41,13 +42,11 @@ import logging
 import os
 import re
 import time
-
 from base64 import b64decode
 from enum import Enum
 from urllib import request
 
 import aiohttp
-import asyncio
 
 logger = logging.getLogger()
 

--- a/src/function.py
+++ b/src/function.py
@@ -603,7 +603,7 @@ def _get_trace_id(message_str):
 
     v2-str (.NET, Ruby, Go):
         [2, "NR_LAMBDA_MONITORING", {metadata_dict}, "<base64_gzip>"]
-        Decompressed payload: {"analytic_event_data": ..., "span_event_data": ...}  (flat, no "data" wrapper)
+        Decompressed payload: flat dict — no "data" wrapper.
 
     v2-dict (Java NewRelicAgentJava):
         [2, "NR_LAMBDA_MONITORING", {metadata_dict}, {data_dict}]


### PR DESCRIPTION
## Summary

- `_get_trace_id` only handled the v1 payload format (Python, Node.js). All v2 agents (.NET, Ruby, Go, Java) produced `Failed to decode payload` and no `trace.id` was attached to log records.
- Adds tab-prefix stripping in `_package_log_payload` for `.NET`: the .NET Lambda runtime wraps `Console.SetOut` and prepends `timestamp\treqId\tinfo\t` to all `Console.WriteLine` output, making the raw message unparseable as JSON.

## Clarification: enhancement, not a critical Logs-in-Context fix

New Relic's Logs-in-Context for Lambda functions already works via `aws.lambda_request_id` → `aws.requestId` matching. NR uses `aws.requestId` from Lambda spans in a trace to find matching log records — this works for all parent entity types (Lambda, APM service, etc.) because the Lambda's own spans carry `aws.requestId` regardless of what service originated the trace.

This PR adds the standard W3C `trace.id` field to log records, which:
- Provides an additional, complementary correlation path (W3C standard)
- Improves reliability when logs arrive before spans are fully indexed
- Is required for tooling or queries that rely on `trace.id` for log-trace correlation

Both mechanisms were validated in a live sandbox:
- Lambda→Lambda DT: **248 logs** visible in parent trace Logs tab **without** this fix (via `aws.lambda_request_id`)
- APM→Lambda DT: **81 logs** visible in parent trace Logs tab **without** this fix (same mechanism)
- With this fix: logs also found via `trace.id`, both paths active simultaneously

## NR_LAMBDA_MONITORING payload formats confirmed

| Agent | `message[0]` | Array len | `message[3]` type | `["data"]` wrap |
|-------|---|---|---|---|
| Python, Node.js | 1 | 3 | — (payload at [2]) | Yes |
| .NET, Ruby, Go | 2 | 4 | `str` (base64+gzip) | No |
| Java (NewRelicAgentJava) | 2 | 4 | `dict` (plain JSON) | No |

## Changes

**`_get_trace_id`**: 3-path logic based on `message[0]` and `isinstance(message[3], str)`:
- v1 → `b64decode(message[2])` + decompress + `["data"]` unwrap (unchanged)
- v2-str → `b64decode(message[3])` + decompress (no unwrap)
- v2-dict → use `message[3]` directly (Java)

**`_package_log_payload`**: strip `timestamp\treqId\tinfo\t` tab-prefix when `NEW_RELIC_FORMAT_LOGS=True` before calling `_get_trace_id` (.NET-specific; safe for all other agents which produce no tab prefix).

## Test results

- [x] All 4 v2-format runtimes now have `trace.id` on log records (was 0): .NET 18/240, Java 4/36, Ruby 360/489, Go 2/9
- [x] Python/Node.js: v1 path unmodified, no regression
- [x] `aws.lambda_request_id` Logs-in-Context continues to work unchanged
- [x] `NEW_RELIC_FORMAT_LOGS=true` required on aws-log-ingestion for `.NET` tab-stripping to fire

## Related

Companion PR to `newrelic/newrelic-dotnet-agent` that writes the payload to fd 1 directly, bypassing the `.NET` Lambda runtime log prefix: https://github.com/newrelic/newrelic-dotnet-agent/pull/3617. Once that ships, `NEW_RELIC_FORMAT_LOGS` is no longer required for `.NET`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
