### PR TITLE
Couple Lambda build to runtime so package matches deployed runtime (#147)

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -50,6 +50,12 @@ variable "lambda_image_name" {
   default     = "newrelic-log-ingestion"
 }
 
+variable "runtime" {
+  type        = string
+  description = "Python runtime for the Lambda function. Exposed so consumers can stage a runtime upgrade in lock-step with a package rebuild (see triggers on null_resource.build_lambda) rather than picking up a new runtime against a previously-built package."
+  default     = "python3.13"
+}
+
 variable "memory_size" {
   type        = number
   description = "Memory size for the New Relic Log Ingestion Lambda function"
@@ -144,6 +150,22 @@ resource "null_resource" "build_lambda" {
   // Depends on log group, just in case this is created in a brand new AWS Subaccount, and it doesn't have subscriptions yet.
   depends_on = [aws_cloudwatch_log_group.lambda_logs]
 
+  // Re-run the docker build whenever any input that affects the produced
+  // package changes. Without these triggers, a module upgrade that bumps
+  // the Lambda runtime (e.g. python3.12 -> python3.13) will update the
+  // runtime attribute on aws_lambda_function.ingestion_function without
+  // rebuilding the bundled package, leaving existing deployments running
+  // a stale package against a newer runtime (e.g. Runtime.ImportModuleError
+  // for `cgi` against python3.13).
+  triggers = {
+    runtime        = var.runtime
+    dockerfile_sha = filesha256("${path.module}/Dockerfile")
+    src_sha = sha256(join("", [
+      for f in sort(fileset("${path.module}/src", "**")) :
+      filesha256("${path.module}/src/${f}")
+    ]))
+  }
+
   provisioner "local-exec" {
     // OS Agnostic folder creation.
     command = (local.archive_folder != "."
@@ -182,7 +204,7 @@ resource "aws_lambda_function" "ingestion_function" {
     ? var.function_role
     : aws_iam_role.lambda_role.0.arn
   )
-  runtime     = "python3.13"
+  runtime     = var.runtime
   filename    = local.archive_name
   handler     = "function.lambda_handler"
   memory_size = var.memory_size


### PR DESCRIPTION
## Summary

Closes the operational hazard surfaced in #147: the module hardcodes the Lambda runtime on `aws_lambda_function.ingestion_function` and `null_resource.build_lambda` has no `triggers`, so on an existing deployment a runtime bump (e.g. `python3.12` → `python3.13`) updates only the runtime attribute and leaves the previously-built package in place. That ships a stale package against a newer runtime and breaks every invocation — concretely, the deployed `aiohttp 3.7.4` `import cgi` runs on `python3.13` and the function fails with `Runtime.ImportModuleError: No module named 'cgi'`. A clean build of HEAD is fine; the breakage is specific to in-place upgrades.

This PR couples the build to the runtime in two ways:

1. **Expose `runtime` as a variable** (default unchanged: `"python3.13"`). Gives consumers an explicit knob to stage a runtime change rather than inheriting it from an unpinned `source` reference.
2. **Add `triggers` to `null_resource.build_lambda`** keyed on `var.runtime` plus a content hash of the build inputs (`Dockerfile` + `src/` tree). Any change to the runtime or to the build inputs now re-runs `docker build`, and since `aws_lambda_function.ingestion_function.filename` reads the resulting zip, the package and the deployed runtime move in lock-step.

## Adoption behavior

On the first apply after picking up this version, the `triggers` map goes from null to populated, which forces a one-time rebuild of `null_resource.build_lambda`. That is the desired self-heal for anyone currently stuck on `python3.13`-runtime + stale `aiohttp 3.7.4` package: the forced rebuild produces a clean `python3.13`-compatible package, matching the `aiohttp==3.13.5` already pinned in `src/requirements.txt`.

For new deployments, behavior is unchanged.

## Verification

- `terraform fmt -check` — clean.
- `terraform validate` — passes. (The one warning is pre-existing on `data.aws_region.current.name`, unrelated to this change.)

## Diff highlights

```diff
+variable "runtime" {
+  type        = string
+  description = "Python runtime for the Lambda function. ..."
+  default     = "python3.13"
+}

 resource "null_resource" "build_lambda" {
   count = var.build_lambda ? 1 : 0
   depends_on = [aws_cloudwatch_log_group.lambda_logs]

+  triggers = {
+    runtime        = var.runtime
+    dockerfile_sha = filesha256("${path.module}/Dockerfile")
+    src_sha = sha256(join("", [
+      for f in sort(fileset("${path.module}/src", "**")) :
+      filesha256("${path.module}/src/${f}")
+    ]))
+  }
   ...
 }

 resource "aws_lambda_function" "ingestion_function" {
-  runtime     = "python3.13"
+  runtime     = var.runtime
```